### PR TITLE
case insensitive user queries

### DIFF
--- a/src/main/java/org/topicquests/backside/servlet/apps/admin/api/IInviteSchema.java
+++ b/src/main/java/org/topicquests/backside/servlet/apps/admin/api/IInviteSchema.java
@@ -28,7 +28,7 @@ public interface IInviteSchema {
         "CREATE INDEX inviteindex ON invites(email)"};
 	
 	  public final String getInvite =
-	      "SELECT email FROM invites WHERE email=?";
+	      "SELECT email FROM invites WHERE lower(email)=lower(?)";
 	  public final String insertInvite =
 	      "INSERT INTO invites (email) VALUES(?)";
 	  public final String removeInvite =

--- a/src/main/java/org/topicquests/backside/servlet/apps/usr/api/IUserSchema.java
+++ b/src/main/java/org/topicquests/backside/servlet/apps/usr/api/IUserSchema.java
@@ -50,9 +50,9 @@ public interface IUserSchema {
 			"CREATE INDEX propindex ON userprops(name)"};
 	
 	public static final String getUserByEmail =
-			"SELECT * FROM users WHERE email=?";
+			"SELECT * FROM users WHERE lower(email)=lower(?)";
 	public static final String getUserByName =
-			"SELECT * FROM users WHERE name=?";
+			"SELECT * FROM users WHERE lower(name)=lower(?)";
 	public static final String removeUser =
 			"DELETE FROM users WHERE name=?";
 	public static final String updateUserPwd = 
@@ -62,8 +62,8 @@ public interface IUserSchema {
 	public static final String updateUserEmail = 
 			"UPDATE users  SET email=? WHERE name=?";
 	
-	public static final String getUserProperties = 
-			"SELECT * FROM userprops WHERE name=?";
+	public static final String getUserProperties =
+			"SELECT * FROM userprops WHERE lower(name)=lower(?)";
 	
 	public static final String updateUserProperty =
 			"UPDATE userprops  SET val=? WHERE prop=? AND name=?";


### PR DESCRIPTION
Why don't we compare usernames and email addresses in lower case? This way we can preserve input case without breaking things if the user types their email or handle differently in a subsequent operation.

closes #8
